### PR TITLE
Fix: Health endpoint explicitly returns HTTP 200

### DIFF
--- a/api/endpoints.py
+++ b/api/endpoints.py
@@ -111,7 +111,7 @@ async def unfold_step_to_svg(
         raise HTTPException(status_code=500, detail=f"予期しないエラー: {str(e)}")
 
 # --- ヘルスチェック ---
-@router.get("/api/health")
+@router.get("/api/health", status_code=200)
 async def api_health_check():
     return {
         "status": "healthy" if OCCT_AVAILABLE else "degraded",


### PR DESCRIPTION
## Summary
- Add explicit `status_code=200` parameter to `/api/health` endpoint decorator
- Makes HTTP status code explicit rather than relying on FastAPI defaults
- No functional changes to the API response

## Related Issue
Fixes #16

## Test Plan
- [ ] Start the server with `python main.py`
- [ ] Run `curl -I http://localhost:8001/api/health`
- [ ] Verify response shows `HTTP/1.1 200 OK`
- [ ] Verify JSON response body remains unchanged

## Changes
- Modified `api/endpoints.py` line 114 to add `status_code=200` parameter

🤖 Generated with [Claude Code](https://claude.ai/code)